### PR TITLE
Issue 4429 - NULL dereference in revert_cache()

### DIFF
--- a/ldap/servers/slapd/back-ldbm/cache.c
+++ b/ldap/servers/slapd/back-ldbm/cache.c
@@ -614,6 +614,9 @@ flush_hash(struct cache *cache, struct timespec *start_time, int32_t type)
 void
 revert_cache(ldbm_instance *inst, struct timespec *start_time)
 {
+    if (inst == NULL) {
+        return;
+    }
     flush_hash(&inst->inst_cache, start_time, ENTRY_CACHE);
     flush_hash(&inst->inst_dncache, start_time, DN_CACHE);
 }


### PR DESCRIPTION
Bug Description:  During a delete, if the DN (with an escaped leading space)
                  of an existing entry fail to parse the server will revert
                  the entry update.  In this case it will lead to a crash
                  becuase ther ldbm inst struct is not set before it attempts
                  the cache revert.

Fix Description:  Check the the ldbm instance struct is not NULL before
                  dereferencing it.

Relates: https://github.com/389ds/389-ds-base/issues/4429

Reviewed by: firstyear & spichugi(Thanks!!)